### PR TITLE
analog: Enable loading local config in hardware modules

### DIFF
--- a/modules/server/analog.cpp
+++ b/modules/server/analog.cpp
@@ -1300,7 +1300,9 @@ void ModuleGroup::buildGroup(ModuleGroup* group, ObjList& spanList, String& erro
 	String* s = static_cast<String*>(o->get());
 	if (s->null())
 	    continue;
-	SignallingCircuitSpan* span = buildSpan(*s,start);
+	NamedList spanParams(*s);
+	spanParams.addParam("local-config","true");
+	SignallingCircuitSpan* span = buildSpan(*s,start,&spanParams);
 	if (!span) {
 	    error << "Failed to build span '" << *s << "'";
 	    break;


### PR DESCRIPTION
_Fixes a long-standing bug (13 years ago, see 33ba0e29fc2849a928ba1c9b60487fc919880ec7)  where the `analog` module would construct a **SignallingCircuitSpan** without the `local-config` attribute, hence causing the hardware modules to be misconfigured._

In example, it would produce an error as such from the `zapcard` module:
```
Section '<span-name in analog.conf>'. Invalid offset='' 
```
when the configuration indeed included an `offset` key correctly set-up.

This was caused by the configuration being loaded and immediately being discarded on here: https://github.com/lowlevl/yate/blob/master/modules/server/zapcard.cpp#L1711 because `local-config` wasn't set.

---

#### A little note on _why_ this is submitted here and not in `yatevoip/yate`:

I at first considered proposing this patch to `yatevoip/yate` I however noticed that the project was basically dead: there were no reviews or answers on patches or issues from the development team there from several years ago,  I also noticed that the official tarball server went down some time ago (yate.null.ro), for which I sent a kind heads up email to the Null team that got left unanswered.

This fork looks like the most promising in terms of features and bug fixes, and the fact that Yate is being used for congresses (where I learned about it, by the way, thanks !) makes me confident in that there could be at least minimal community-driven maintenance.

I would also get that you wanted to maintain your fork for the patches you made and not become a hub for the contributions for Yate !

Thanks.